### PR TITLE
Fix case where new dependency is introduced by a linked pod

### DIFF
--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -131,6 +131,9 @@ module Pod
               inner_before_index = find_pod_index before, key_desc
               puts "KEY "+ key_desc
               puts "BEFORE_ARRAY "+ before.to_s 
+              puts "---------"
+              puts "AFTER ARRAY " + after.to_s
+              puts "---------"
               puts "before "+ inner_before_index.to_s
               puts "after "+ inner_after_index.to_s
               unless inner_before_index.nil? && inner_after_index.nil?

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -129,7 +129,9 @@ module Pod
 
               inner_after_index = find_pod_index after, key_desc
               inner_before_index = find_pod_index before, key_desc
-              
+              puts "KEY "+ key_desc
+              puts "before "+ inner_before_index.to_s
+              puts "after "+ inner_after_index.to_s
               unless inner_before_index.nil? || inner_after_index.nil?
                 after[inner_after_index] = before[inner_before_index]
               else 

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -131,7 +131,7 @@ module Pod
               inner_after_index = find_pod_index after, key_desc
               inner_before_index = find_pod_index before, key_desc
               
-              unless inner_before_index.nil? && inner_after_index.nil?
+              unless inner_before_index.nil? || inner_after_index.nil?
                 after[inner_after_index] = before[inner_before_index]
               else 
                 # if it was removed in the new deps

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -127,7 +127,6 @@ module Pod
               # key: CocoaLumberjack/Core or CocoaLumberjack/Extensions (= 1.9.2)
               key_desc = key.split(" (", 2)[0]
 
-              puts "DEBUG: " + key_desc
               inner_after_index = find_pod_index after, key_desc
               inner_before_index = find_pod_index before, key_desc
               

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -132,7 +132,6 @@ module Pod
               inner_before_index = find_pod_index before, key_desc
               
               unless inner_before_index.nil? && inner_after_index.nil?
-                puts "DEBUG: "+ after
                 after[inner_after_index] = before[inner_before_index]
               else 
                 # if it was removed in the new deps

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -130,9 +130,10 @@ module Pod
               inner_after_index = find_pod_index after, key_desc
               inner_before_index = find_pod_index before, key_desc
               puts "KEY "+ key_desc
+              puts "BEFORE_ARRAY "+ before.to_s 
               puts "before "+ inner_before_index.to_s
               puts "after "+ inner_after_index.to_s
-              unless inner_before_index.nil? || inner_after_index.nil?
+              unless inner_before_index.nil? && inner_after_index.nil?
                 after[inner_after_index] = before[inner_before_index]
               else 
                 # if it was removed in the new deps

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -127,10 +127,12 @@ module Pod
               # key: CocoaLumberjack/Core or CocoaLumberjack/Extensions (= 1.9.2)
               key_desc = key.split(" (", 2)[0]
 
+              puts "DEBUG: " + key_desc
               inner_after_index = find_pod_index after, key_desc
               inner_before_index = find_pod_index before, key_desc
               
               unless inner_before_index.nil? && inner_after_index.nil?
+                puts "DEBUG: " after
                 after[inner_after_index] = before[inner_before_index]
               else 
                 # if it was removed in the new deps

--- a/lib/pod/lockfile.rb
+++ b/lib/pod/lockfile.rb
@@ -132,7 +132,7 @@ module Pod
               inner_before_index = find_pod_index before, key_desc
               
               unless inner_before_index.nil? && inner_after_index.nil?
-                puts "DEBUG: " after
+                puts "DEBUG: "+ after
                 after[inner_after_index] = before[inner_before_index]
               else 
                 # if it was removed in the new deps


### PR DESCRIPTION
If a new dependency is added in a linked pod, `lib/pod/lockfile.rb` would crash because the `unless` clause only checked if both IDs were nil, instead of one of them.